### PR TITLE
misses out on keyboard lib when copy/paste commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
  make
  make install
  cd ..
- cd libOrbisKeyboard
+ cd liborbisKeyboard
  make
  make install
  cd ..


### PR DESCRIPTION
liborbisKeyboard not libOrbisKeyboard, maybe next put into install.sh?