### PR TITLE
Fix some warnings for implicit declaration of functions

### DIFF
--- a/libelfloader/source/elfloader.c
+++ b/libelfloader/source/elfloader.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <sys/mman.h>
+
 #include <elfloader.h>
 
 /* Defines */

--- a/liborbisAudio/source/orbisAudio.c
+++ b/liborbisAudio/source/orbisAudio.c
@@ -10,6 +10,7 @@
 #include <kernel.h>
 #include <audioout.h>
 #include <debugnet.h>
+#include <unistd.h>
 #include "orbisAudio.h"
 
 

--- a/liborbisKeyboard/source/orbisKeyboard.c
+++ b/liborbisKeyboard/source/orbisKeyboard.c
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <userservice.h>
 #include <sysmodule.h>
+#include <unistd.h>
 
 #include "orbisKeyboard.h"
 #include "kb.h"

--- a/libps4link/source/jailbreak.c
+++ b/libps4link/source/jailbreak.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <kernel.h>
 #include <sys/mman.h>
+#include <debugnet.h>
 
 #define	CTL_KERN	1	/* "high kernel": proc, limits */
 #define	KERN_PROC	14	/* struct: process entries */

--- a/libps4link/source/jailbreak.c
+++ b/libps4link/source/jailbreak.c
@@ -2,6 +2,7 @@
 #include <kernel.h>
 #include <sys/mman.h>
 #include <debugnet.h>
+#include <unistd.h>
 
 #define	CTL_KERN	1	/* "high kernel": proc, limits */
 #define	KERN_PROC	14	/* struct: process entries */


### PR DESCRIPTION
### Used dependencies

[`firmware505` branch](https://github.com/psxdev/ps4sdk/tree/firmware505) of https://github.com/psxdev/ps4sdk ([at commit df03b9fd274ec5dabf105a07e6cb9f0bf6685801](https://github.com/psxdev/ps4sdk/commit/df03b9fd274ec5dabf105a07e6cb9f0bf6685801)).

### Solved implicit declarations

For `libelfloader`:
```
    default: source/elfloader.c:690:3: warning: implicit declaration of function 'munmap' is invalid in C99 [-Wimplicit-function-declaration]
    default:                 munmap(elf->data,elf->size);
    default:                 ^
```

For `libps4link`:
```
    default: source/jailbreak.c:119:2: warning: implicit declaration of function 'debugNetPrintf' is invalid in C99 [-Wimplicit-function-declaration]
    default:         debugNetPrintf(3,"td %x",td);
    default:         ^
    default: source/jailbreak.c:126:6: warning: implicit declaration of function 'syscall' is invalid in C99 [-Wimplicit-function-declaration]
    default:         ret=syscall(11,jailbreak,td,dump);
```

For `liborbisAudio`:
```
    default: source/orbisAudio.c:381:3: warning: implicit declaration of function 'sleep' is invalid in C99 [-Wimplicit-function-declaration]
    default:                 sleep(2);
    default:                 ^
```

For `liborbisKeyboard`:
```
    default: source/orbisKeyboard.c:619:2: warning: implicit declaration of function 'sleep' is invalid in C99 [-Wimplicit-function-declaration]
    default:         sleep(1);
    default:         ^
```

### Pending implicit declarations

There are two pending implicit declarations that I don't know how to solve properly. These are not solved by this PR:
For `libps4link`:
```
    default: source/commands.c:679:6: warning: implicit declaration of function 'sysctl' is invalid in C99 [-Wimplicit-function-declaration]
    default:                 if(sysctl(mib,4,NULL,&len,NULL,0)!=-1) 
    default:                    ^
    default: source/commands.c:732:6: warning: implicit declaration of function 'ptrace' is invalid in C99 [-Wimplicit-function-declaration]
    default:         ret=ptrace(PT_ATTACH,i,NULL,NULL);
    default:             ^
```
In my attempts of solving these, I figured:
* `sys/sysctl.h` is already included on [source/commands.c:34](https://github.com/orbisdev/liborbis/blob/master/libps4link/source/commands.c#L34)
* `sys/ptrace.h` is already included on [source/commands.c:36](https://github.com/orbisdev/liborbis/blob/master/libps4link/source/commands.c#L36)
* the declaration for `sysctl` is on [sys/sysctl.h:793](https://github.com/psxdev/ps4sdk/blob/df03b9fd274ec5dabf105a07e6cb9f0bf6685801/include/sys/sysctl.h#L793) when `_KERNEL` is not defined [sys/sysctl.h:789](https://github.com/psxdev/ps4sdk/blob/df03b9fd274ec5dabf105a07e6cb9f0bf6685801/include/sys/sysctl.h#L789) 
* the declaration for `ptrace` is on [sys/ptrace.h:188](https://github.com/psxdev/ps4sdk/blob/df03b9fd274ec5dabf105a07e6cb9f0bf6685801/include/sys/ptrace.h#L188) when `_KERNEL` is not defined [sys/ptrace.h:183](https://github.com/psxdev/ps4sdk/blob/df03b9fd274ec5dabf105a07e6cb9f0bf6685801/include/sys/ptrace.h#L183)
* `_KERNEL` is defined on [ps4/kernel.h:3](https://github.com/psxdev/ps4sdk/blob/df03b9fd274ec5dabf105a07e6cb9f0bf6685801/include/ps4/kernel.h#L3)
* `ps4/kernel.h` is included on [source/commands.c:27](https://github.com/orbisdev/liborbis/blob/master/libps4link/source/commands.c#L27) (before `sys/sysctl.h` and `sys/ptrace.h`)

Based on this I conclude that including `ps4/kernel.h` before `sys/sysctl.h` and `sys/ptrace.h` makes `sysctl` and `ptrace` to not be defined.

I tried moving the `#include <sys/sysctl.h>` before the `#include <ps4/kernel.h>`. This seems to work for `sysctl`.
I also tried moving the `#include <sys/ptrace.h>` before the `#include <ps4/kernel.h>`. But this resulted in 4 errors:
```
source/commands.c:500:10: error: use of undeclared identifier 'TRUE'
                return TRUE;
                       ^
source/commands.c:505:10: error: use of undeclared identifier 'FALSE'
                return FALSE;
                       ^
source/commands.c:524:13: error: use of undeclared identifier 'TRUE'
                                        return TRUE;
                                               ^
source/commands.c:529:9: error: use of undeclared identifier 'FALSE'
        return FALSE;
               ^
```

For this I figured:
* `TRUE` and `FALSE` are defined from [sys/param.h:101](https://github.com/psxdev/ps4sdk/blob/df03b9fd274ec5dabf105a07e6cb9f0bf6685801/include/sys/param.h#L101) when `_KERNEL` is defined on [sys/param.h:93](https://github.com/psxdev/ps4sdk/blob/df03b9fd274ec5dabf105a07e6cb9f0bf6685801/include/sys/param.h#L93) 
* [sys/ptrace.h:37](https://github.com/psxdev/ps4sdk/blob/df03b9fd274ec5dabf105a07e6cb9f0bf6685801/include/sys/ptrace.h#L37) includes `sys/param.h`

Based on this I conclude that including `sys/ptrace.h` before `ps4/kernel.h` makes `TRUE` and `FALSE` to not be defined.

I don't see a solution to this problem without modifying `sys/ptrace.h` or `ps4/kernel.h`.
Any ideas?