### PR TITLE
move ARGB color facilities from orbisXbmFont to main orbis2d lib

### DIFF
--- a/liborbis2d/include/orbis2d.h
+++ b/liborbis2d/include/orbis2d.h
@@ -22,6 +22,16 @@
 #define ATTR_HEIGHT 720
 
 
+// compose ARGB color by components
+#define ARGB(a, r, g, b) ( \
+          (((a) &0xFF) <<24) | (((r) &0xFF) <<16) | \
+          (((g) &0xFF) << 8) | (((b) &0xFF) << 0))
+
+// extract single component form ARGB color
+#define GET_A(color) ((color >>24) &0xFF)
+#define GET_R(color) ((color >>16) &0xFF)
+#define GET_G(color) ((color >> 8) &0xFF)
+#define GET_B(color) ((color >> 0) &0xFF)
 
 
 typedef struct Orbis2dConfig

--- a/liborbisXbmFont/include/orbisXbmFont.h
+++ b/liborbisXbmFont/include/orbisXbmFont.h
@@ -20,18 +20,6 @@
 #define SIMPLE_GRADIENT_STEPS    ((uint8_t)(FONT_H /2))  // steps we split delta
 
 
-// compose ARGB color by components
-#define ARGB(a, r, g, b) ( \
-          (((a) &0xFF) <<24) | (((r) &0xFF) <<16) | \
-          (((g) &0xFF) << 8) | (((b) &0xFF) << 0))
-
-// extract single component form ARGB color
-#define GET_A(color) ((color >>24) &0xFF)
-#define GET_R(color) ((color >>16) &0xFF)
-#define GET_G(color) ((color >> 8) &0xFF)
-#define GET_B(color) ((color >> 0) &0xFF)
-
-
 /***********************************************************************
 * update_gradient
 *

--- a/liborbisXbmFont/source/orbisXbmFont.c
+++ b/liborbisXbmFont/source/orbisXbmFont.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#include <orbis2d.h>  // orbis2dDrawPixelColor()
+#include <orbis2d.h>  // orbis2dDrawPixelColor(), ARGB(), GET_A(), GET_R(), GET_G(), GET_B()
 
 #include "orbisXbmFont.h"
 


### PR DESCRIPTION
So, even if don't using XbmFont, we can make use of that macros without the need to include _orbisXbmFont.h_ header