### PR TITLE
reuse code to read files, and let autodetect where look for

### DIFF
--- a/libmod/source/modplayer.c
+++ b/libmod/source/modplayer.c
@@ -111,8 +111,8 @@ static int m_TrackDat_num;
 static TrackData *m_TrackDat;	// Stores info for each track being played
 static RowData *m_CurrentRow;	// Pointer to the current row being played
 static int m_bPlaying;		// Set to true when a mod is being played
-static u8 *data;
-int size = 0;
+static u8 *data = NULL;
+
 //////////////////////////////////////////////////////////////////////
 // These are the public functions
 //////////////////////////////////////////////////////////////////////
@@ -183,8 +183,7 @@ void Mod_FreeTune()
 
     // Tear down all the mallocs done
     //free the file itself
-    if (data)
-	free(data);
+    if (data) free(data), data = NULL;
     // Free patterns
     for (i = 0; i < m_Patterns_num; i++) {
 	for (row = 0; row < 64; row++)
@@ -251,25 +250,11 @@ int Mod_Load(char *filename)
     int index = 0;
     int numsamples;
     char modname[21];
-    int fd;	
-    if ((fd = ps4LinkOpen(filename, O_RDONLY, 0)) > 0) {
-	//  opened file, so get size now
-	size = ps4LinkLseek(fd, 0, SEEK_END);
-	ps4LinkLseek(fd, 0, SEEK_SET);
-	data = (unsigned char *) malloc(size + 8);
-	memset(data, 0, size + 8);
-	if (data != 0) {	// Read file in
-	    ps4LinkRead(fd, data, size);
-	} else {
-	    printf("Error allocing\n");
-	    ps4LinkClose(fd);
-	    return 0;
-	}
-	// Close file
-	ps4LinkClose(fd);
-    } else {			//if we couldn't open the file
-	return 0;
-    }
+
+    // allocate 8 bytes more than readed
+    data = DataFromFile(filename, 8);
+    if(!data)
+        return 0;
 
     //BPM_RATE = 130;
 	BPM_RATE = 125; //PAL

--- a/liborbis2d/source/orbis2dImagePng.c
+++ b/liborbis2d/source/orbis2dImagePng.c
@@ -163,41 +163,9 @@ exit_error:
 
 Orbis2dTexture *orbis2dLoadPngFromHost_v2(const char *path)
 {
-	int fd;             // descriptor to manage file from host0
-	int filesize;       // variable to control file size
-	uint8_t *buf=NULL;  // buffer for read from host0 file
+	uint8_t *buf=DataFromFile(path, 0);
 
-	// we open file in read only from host0 ps4sh include the full path with host0:/.......
-	fd=ps4LinkOpen(path,O_RDONLY,0);
-
-	if(fd<0)  //If we can't open file from host0 print  the error and return
-	{
-		debugNetPrintf(DEBUG,"[PS4LINK] ps4LinkOpen returned error %d\n",fd);
-		return NULL;
-	}
-	filesize=ps4LinkLseek(fd,0,SEEK_END);  // Seek to end to get file size
-	if(filesize<0)                         // If we get an error print it and return
-	{
-		debugNetPrintf(DEBUG,"[PS4LINK] ps4LinkSeek returned error %d\n",fd);
-		ps4LinkClose(fd);
-		return NULL;
-	}
-
-	ps4LinkLseek(fd,0,SEEK_SET);  // Seek back to start
-	buf=malloc(filesize);         // Reserve memory for read buffer
-	if(!buf)
-		return NULL;
-
-	int numread=ps4LinkRead(fd,buf,filesize);  //Read filsesize bytes to buf
-	ps4LinkClose(fd);  //Close file
-
-	if(numread!=filesize)  //if we don't get filesize bytes we are in trouble
-	{
-		debugNetPrintf(DEBUG,"[PS4LINK] ps4LinkRead returned error %d\n",numread);
-		return NULL;
-	}
-
-	return orbis2dLoadPngFromBuffer(buf);  //create png from buf
+    return orbis2dLoadPngFromBuffer(buf);  // create png from buf
 }
 
 // uses standard open/lseek/read/close to access sandbox'ed content

--- a/libps4link/include/ps4link.h
+++ b/libps4link/include/ps4link.h
@@ -65,6 +65,7 @@ typedef struct OrbisDirEntry
 	char name[256];
 }OrbisDirEntry;
 
+uint8_t *DataFromFile(const char *path, int additional_size);
 
 int ps4LinkOpen(const char *file, int flags, int mode);
 int ps4LinkClose(int fd);


### PR DESCRIPTION
this one will autodetect if looking via host0 or local just by looking at path, so we can just copy file in mem, then use it as .mod/.png etc with a little wrapper

also, we can now switch _orbis2dLoadPngFromHost_v2_ to more generic **orbis2dLoadPngFromFile**, and remove last added _orbis2dLoadPngFromSandbox_ now useless