### PR TITLE
liborbisFile: little review

### DIFF
--- a/liborbisFile/include/orbisFile.h
+++ b/liborbisFile/include/orbisFile.h
@@ -22,7 +22,7 @@ int orbisDopen(const char *path);
 int orbisDclose(int dfd);
 int orbisDread(int dfd, struct dirent *entry);
 int orbisMkdir(const char *path, int mode);
-char * orbisFileGetFileContent(const char *file);
+unsigned char * orbisFileGetFileContent(const char *file);
 int orbisFileInit();
 void orbisFileFinish();
 	

--- a/liborbisNfs/include/config.h
+++ b/liborbisNfs/include/config.h
@@ -154,3 +154,8 @@
 
 /* Define for large files, on AIX-style hosts. */
 /* #undef _LARGE_FILES */
+
+#ifdef __PS4__
+#include <debugnet.h>
+#include <sce/net.h>
+#endif

--- a/libps4link/source/ps4link.c
+++ b/libps4link/source/ps4link.c
@@ -302,7 +302,8 @@ int ps4LinkIsFinished()
  */
 void ps4LinkFinish()
 {
-	if(!external_conf)
+	if(!external_conf
+	&& configuration)
 	{
 		configuration->ps4link_fileio_active=0;
 		configuration->ps4link_cmdsio_active=0;


### PR DESCRIPTION
## libOrbisFile
- orbisFileGetFileContent become unsigned, since we use to read data buffers;
- review debug default logic: feedback on error, else be quiet;
- rearrange for initial checks in functions;
- debug remote fd slot we use, to check if we leaks around...

## libps4link
- [x] fix clean exit on new samplenfs